### PR TITLE
Fix pagination normalization for unit listing

### DIFF
--- a/backend/controllers/unitController.js
+++ b/backend/controllers/unitController.js
@@ -554,14 +554,13 @@ class unitController {
 
   static async listUnits(req, res) {
     try {
-      const page = Number(req.query.page) || 1;
-      const limit = Number(req.query.limit) || 1;
-
-      if (page <= 0) {
+      let page = Number(req.query.page);
+      if (!Number.isInteger(page) || page <= 0) {
         page = 1;
       }
 
-      if (limit <= 0 || limit > 100) {
+      let limit = Number(req.query.limit);
+      if (!Number.isInteger(limit) || limit <= 0 || limit > 100) {
         limit = 5;
       }
 

--- a/backend/tests/unitController.test.js
+++ b/backend/tests/unitController.test.js
@@ -1,0 +1,115 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import unitController from "../controllers/unitController.js";
+import prisma from "../DB/db.config.js";
+
+test("listUnits normalizes invalid pagination params", async (t) => {
+  const originalAdminFindUnique = prisma.admin.findUnique;
+  const originalUnitFindMany = prisma.unit.findMany;
+  const originalUnitCount = prisma.unit.count;
+
+  t.after(() => {
+    prisma.admin.findUnique = originalAdminFindUnique;
+    prisma.unit.findMany = originalUnitFindMany;
+    prisma.unit.count = originalUnitCount;
+  });
+
+  prisma.admin.findUnique = async () => ({
+    adminId: "admin",
+    institutionId: "institution",
+  });
+
+  let capturedFindManyArgs;
+  prisma.unit.findMany = async (args) => {
+    capturedFindManyArgs = args;
+    return [{ unitId: "unit" }];
+  };
+
+  prisma.unit.count = async () => 12;
+
+  const req = {
+    query: { page: "-1", limit: "0" },
+    admin: { adminId: "admin" },
+  };
+
+  const responses = [];
+  const res = {
+    status(code) {
+      responses.push({ type: "status", code });
+      return this;
+    },
+    json(payload) {
+      responses.push({ type: "json", payload });
+      return this;
+    },
+  };
+
+  await unitController.listUnits(req, res);
+
+  assert.ok(capturedFindManyArgs, "findMany should be called");
+  assert.equal(capturedFindManyArgs.take, 5, "limit should default to 5");
+  assert.equal(capturedFindManyArgs.skip, 0, "skip should match page 1 with limit 5");
+
+  const jsonResponse = responses.find((item) => item.type === "json");
+  assert.ok(jsonResponse, "Should return a JSON response");
+  assert.equal(jsonResponse.payload.status, 200, "Should respond with status 200");
+  assert.equal(jsonResponse.payload.metadata.currentPage, 1);
+  assert.equal(jsonResponse.payload.metadata.currentLimit, 5);
+  assert.equal(jsonResponse.payload.metadata.totalPages, Math.ceil(12 / 5));
+});
+
+test("listUnits keeps valid pagination params", async (t) => {
+  const originalAdminFindUnique = prisma.admin.findUnique;
+  const originalUnitFindMany = prisma.unit.findMany;
+  const originalUnitCount = prisma.unit.count;
+
+  t.after(() => {
+    prisma.admin.findUnique = originalAdminFindUnique;
+    prisma.unit.findMany = originalUnitFindMany;
+    prisma.unit.count = originalUnitCount;
+  });
+
+  prisma.admin.findUnique = async () => ({
+    adminId: "admin",
+    institutionId: "institution",
+  });
+
+  let capturedFindManyArgs;
+  prisma.unit.findMany = async (args) => {
+    capturedFindManyArgs = args;
+    return [{ unitId: "unit" }];
+  };
+
+  prisma.unit.count = async () => 34;
+
+  const req = {
+    query: { page: "2", limit: "10" },
+    admin: { adminId: "admin" },
+  };
+
+  const responses = [];
+  const res = {
+    status(code) {
+      responses.push({ type: "status", code });
+      return this;
+    },
+    json(payload) {
+      responses.push({ type: "json", payload });
+      return this;
+    },
+  };
+
+  await unitController.listUnits(req, res);
+
+  assert.ok(capturedFindManyArgs, "findMany should be called");
+  assert.equal(capturedFindManyArgs.take, 10, "limit should remain 10");
+  assert.equal(capturedFindManyArgs.skip, 10, "skip should be (page-1)*limit");
+
+  const jsonResponse = responses.find((item) => item.type === "json");
+  assert.ok(jsonResponse, "Should return a JSON response");
+  assert.equal(jsonResponse.payload.status, 200, "Should respond with status 200");
+  assert.equal(jsonResponse.payload.metadata.currentPage, 2);
+  assert.equal(jsonResponse.payload.metadata.currentLimit, 10);
+  assert.equal(jsonResponse.payload.metadata.totalPages, Math.ceil(34 / 10));
+});


### PR DESCRIPTION
## Summary
- normalize pagination parameters in the unit listing controller to guard against invalid values
- add node-based tests covering invalid and valid pagination scenarios for listUnits

## Testing
- node --test backend/tests/unitController.test.js